### PR TITLE
Switch to project property constant

### DIFF
--- a/Smith.props
+++ b/Smith.props
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Constant Include="UserSecretsId" Value="$(UserSecretsId)" />
+    <ProjectProperty Include="UserSecretsId" />
   </ItemGroup>
 
 </Project>

--- a/cs/AddUserSecrets.cs
+++ b/cs/AddUserSecrets.cs
@@ -14,8 +14,8 @@ public static class UserSecretsConfigurationExtensions
     /// <returns>The configuration builder.</returns>
     public static IConfigurationBuilder AddUserSecrets(this IConfigurationBuilder configuration)
     {
-        if (!string.IsNullOrEmpty(ThisAssembly.Constants.UserSecretsId))
-            return configuration.AddUserSecrets(ThisAssembly.Constants.UserSecretsId, reloadOnChange: false);
+        if (!string.IsNullOrEmpty(ThisAssembly.Project.UserSecretsId))
+            return configuration.AddUserSecrets(ThisAssembly.Project.UserSecretsId, reloadOnChange: false);
 
         return configuration;
     }


### PR DESCRIPTION
This is evaluated later via targets, so it's guaranteed to have the right value regardless of whether it's set via props/targets